### PR TITLE
Bug fix for error in module upon opening one if it does not have toolbar settings

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -325,7 +325,7 @@ export class Grids {
             }
 
             if ((!gridViewSettings.toolbar || !gridViewSettings.toolbar.hideCreateButton) && this.base.settings.permissions.canCreate) {
-                const createButtonSettings = gridViewSettings.toolbar.createButtonSettings;
+                const createButtonSettings = gridViewSettings.toolbar?.createButtonSettings;
                 const createButtonText = createButtonSettings?.text || 'Nieuw item toevoegen';
                 const createButtonIcon = createButtonSettings?.icon || 'plus';
                 


### PR DESCRIPTION
Made the retrieval of the toolbar settings for custom create buttons in modules optional