### PR TITLE
fix/sidebar-scroll-on-minimized-view

### DIFF
--- a/FrontEnd/Core/Scss/masterpage.scss
+++ b/FrontEnd/Core/Scss/masterpage.scss
@@ -831,7 +831,8 @@ main, div, section {
 
             .menu-scroller {
                 width: 100%;
-                overflow: visible;
+                overflow: auto;
+                scrollbar-width: none;
             }
 
             a {


### PR DESCRIPTION
This pull request fixes an issue where the sidebar for navigation on minimized mode (with just the icons) would not allow the user to scroll through the modules.