### PR TITLE
feature/role-condition-on-action-buttons

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1106,10 +1106,14 @@ export class Grids {
             const conditionAttribute = customAction.condition
                 ? `data-condition="${Misc.encodeHtml(customAction.condition)}"`
                 : '';
+
+            const rolesAttribute = customAction.roles
+                ? `data-roles="${Misc.encodeHtml(customAction.roles)}"`
+                : '';
             
             const selector = gridSelector.replace(/#/g, "\\#");
             
-            const { condition, ...customActionData } = customAction;
+            const { condition, roles, ...customActionData } = customAction;
             
             if (customAction.groupName) {
                 let group = groups.filter(g => g.name === customAction.groupName)[0];
@@ -1123,12 +1127,12 @@ export class Grids {
                     groups.push(group);
                 }
                 
-                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
+                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} ${rolesAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
             } else {
                 actionsWithoutGroups.push({
                     name: `customAction${i.toString()}`,
                     text: customAction.text,
-                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
+                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} ${rolesAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
                 });
             }
         }
@@ -1591,6 +1595,7 @@ export class Grids {
         conditionalButtons.each(async function () {
             const button = $(this);
             const condition = button.data('condition');
+            const roles = button.data('roles');
             
             // Do not hide buttons by default.
             let shouldHide = false;
@@ -1618,6 +1623,19 @@ export class Grids {
                 });
             }
             
+            // Roles check.
+            if(roles) {
+                // Retrieve the user data from the local storage.
+                const userDataString = localStorage.getItem('userData');
+                const userData = userDataString ? JSON.parse(userDataString) : [];
+                // Retrieve the role from the user data.
+                const userRole = userData.role;
+                
+                // Check whether the user's role is required by the action button.
+                const rolesArray = roles.split(',').map(role => role.trim());
+                shouldHide = !rolesArray.includes(userRole);
+            }
+
             // Show or hide the action button based on the evaluated condition or default value.
             button.toggleClass('hidden', shouldHide || event.sender.select().length === 0);
         });


### PR DESCRIPTION
This change adds a feature where a new property can be added to a custom action, named `roles`. The `roles` property consists of a comma-separated value of role names. This property checks whether the user is allowed to see the button. If the current user has either one of the roles, the button will become visible. If the user's role is not present in the required roles for the button, the button will be hidden.

**Note:** This update provides a visual change only. It does not include a security check in the back end to check whether the user is allowed to perform the action of the custom action button.