### PR TITLE
fix/collection-literal-not-supported-on-live-development-environment

### DIFF
--- a/Api/Modules/Modules/Services/ModulesService.cs
+++ b/Api/Modules/Modules/Services/ModulesService.cs
@@ -658,7 +658,7 @@ UNION
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("id", id);
             
-            await databaseHelpersService.CheckAndUpdateTablesAsync([ WiserTableNames.WiserModule ]);
+            await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> { WiserTableNames.WiserModule });
 
             var query = $@"SELECT id, custom_query, count_query, `options`, `name`, icon, type, `group`, `custom_script` FROM {WiserTableNames.WiserModule} WHERE id = ?id";
             var dataTable = await clientDatabaseConnection.GetAsync(query);


### PR DESCRIPTION
Fixed a build error on the live development environment by reverting a collection literal expression to the standard list instantiation