### PR TITLE
fix/no-templates-found-for-password-reset

### DIFF
--- a/Api/Modules/Templates/Services/TemplatesService.cs
+++ b/Api/Modules/Templates/Services/TemplatesService.cs
@@ -1277,8 +1277,8 @@ SELECT
     `subject`.`value` AS `subject`,
     IF(template.long_value IS NULL OR template.long_value = '', template.`value`, template.long_value) AS content
 FROM wiser_item AS item
-JOIN wiser_itemdetail AS template ON template.item_id = item.id AND template.`key` = 'template'
-JOIN wiser_itemdetail AS `subject` ON `subject`.item_id = item.id AND `subject`.`key` = 'subject'
+LEFT JOIN wiser_itemdetail AS template ON template.item_id = item.id AND template.`key` = 'template'
+LEFT JOIN wiser_itemdetail AS `subject` ON `subject`.item_id = item.id AND `subject`.`key` = 'subject'
 WHERE item.entity_type = 'template'
 AND item.title = ?templateName
 LIMIT 1";

--- a/Api/Modules/Tenants/Services/UsersService.cs
+++ b/Api/Modules/Tenants/Services/UsersService.cs
@@ -431,6 +431,7 @@ ORDER BY username.`value` ASC";
             await clientDatabaseConnection.ExecuteAsync(query);
 
             var mailTemplate = (await templatesService.GetTemplateByNameAsync("Wachtwoord vergeten", true)).ModelObject;
+            mailTemplate.Subject ??= "Wachtwoord reset";
             mailTemplate.Content = mailTemplate.Content.Replace("{username}", resetPasswordRequestModel.Username).Replace("{password}", password).Replace("{subdomain}", resetPasswordRequestModel.SubDomain);
 
             await communicationsService.SendEmailAsync(resetPasswordRequestModel.EmailAddress, mailTemplate.Subject, mailTemplate.Content);


### PR DESCRIPTION
Adjusted the query for finding templates by name by allowing to find templates if some values are not set. This is necessary to find the mail template when resetting a password.