### PR TITLE
Feature/auto reselect after action button execution

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -842,15 +842,27 @@ export class Fields {
 
         if (success) {
             if (senderGrid) {
+                const grids = this.base.grids;
+
+                const selectedIds = selectedItems.map(item => item.dataItem.id);
+
                 if (actionDetails.rebuildMainGridAfterActions && this.base.settings.gridViewMode) {
                     // Destroy and recreate the grid.
-                    this.base.grids.mainGrid.destroy();
+                    grids.mainGrid.destroy();
                     $("#gridView").empty();
-                    this.base.grids.mainGridFirstLoad = true;
-                    this.base.grids.setupGridViewMode();
+                    grids.mainGridFirstLoad = true;
+                    
+                    // Reset the grid view.
+                    await grids.setupGridViewMode();
                 } else {
-                    senderGrid.dataSource.read();
+                    await senderGrid.dataSource.read();
                 }
+
+                // Reselect earlier stored selected rows.
+                const gridData = senderGrid.dataSource.data();
+                const selectedRowUids = gridData.filter(row => selectedIds.includes(row.id)).map(row => row.uid);
+                const selectedRows = $(gridSelector).find(selectedRowUids.map(uid => `tr[data-uid="${uid}"]`).join(','));
+                grids.mainGrid.select(selectedRows);
             }
 
             if (!actionDetails.disableSuccessMessages) {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -858,11 +858,15 @@ export class Fields {
                     await senderGrid.dataSource.read();
                 }
 
-                // Reselect earlier stored selected rows.
-                const gridData = senderGrid.dataSource.data();
-                const selectedRowUids = gridData.filter(row => selectedIds.includes(row.id)).map(row => row.uid);
-                const selectedRows = $(gridSelector).find(selectedRowUids.map(uid => `tr[data-uid="${uid}"]`).join(','));
-                grids.mainGrid.select(selectedRows);
+                // Check whether the action has it set to deselect the rows after performing an action.
+                const selectAfter = actionDetails.selectAfter ?? true;
+                if(selectAfter) {
+                    // Reselect earlier stored selected rows.
+                    const gridData = senderGrid.dataSource.data();
+                    const selectedRowUids = gridData.filter(row => selectedIds.includes(row.id)).map(row => row.uid);
+                    const selectedRows = $(gridSelector).find(selectedRowUids.map(uid => `tr[data-uid="${uid}"]`).join(','));
+                    grids.mainGrid.select(selectedRows);
+                }
             }
 
             if (!actionDetails.disableSuccessMessages) {


### PR DESCRIPTION
Implementation to auto reselect the earlier selected rows after executing an action on a grid. This feature brings an optional setting `selectAfter` with it that can be set on an action. By default, this is set to `true`.