### PR TITLE
Feature/direct module editing

### DIFF
--- a/Api/Modules/Grids/Models/EditableFieldModel.cs
+++ b/Api/Modules/Grids/Models/EditableFieldModel.cs
@@ -1,0 +1,17 @@
+namespace Api.Modules.Grids.Models;
+
+/// <summary>
+/// A model that defines an editable field from a module.
+/// </summary>
+public class EditableFieldModel
+{
+    /// <summary>
+    /// The name of the associated field that is editable.
+    /// </summary>
+    public string[] Fields { get; set; }
+    
+    /// <summary>
+    /// The query ID from the <c>wiser_query</c> table to execute once the field is updated.
+    /// </summary>
+    public int QueryId { get; set; }
+}

--- a/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
+++ b/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
@@ -68,5 +68,15 @@ namespace Api.Modules.Grids.Models
         /// Gets or sets the language code for the grid. This is used for grids with field groups, to have a group per language code.
         /// </summary>
         public string LanguageCode { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the definitions of editable fields within the module.
+        /// </summary>
+        public EditableFieldModel Editable { get; set; }
+
+        public GridSettingsAndDataModel()
+        {
+            Editable = new EditableFieldModel();
+        }
     }
 }

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2297,6 +2297,8 @@ namespace Api.Modules.Grids.Services
 
         private static void BuildGridSchema(DataTable dataTable, GridSettingsAndDataModel results, bool hasPredefinedColumns)
         {
+            string[] editableFields = results.Editable.Fields;
+            
             foreach (DataColumn dataColumn in dataTable.Columns)
             {
                 string kendoColumnType;
@@ -2337,10 +2339,14 @@ namespace Api.Modules.Grids.Services
                     kendoColumnType = null;
                 }
 
+                bool editableField = 
+                    editableFields.Contains(dataColumn.ColumnName) &&
+                    !dataColumn.ColumnName.Equals("id", StringComparison.OrdinalIgnoreCase);
+
                 results.SchemaModel.Fields.Add(fieldName,
                     new FieldModel
                     {
-                        Editable = !dataColumn.ColumnName.Equals("id", StringComparison.OrdinalIgnoreCase),
+                        Editable = editableField,
                         Nullable = true,
                         Type = kendoColumnType
                     });

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2297,7 +2297,7 @@ namespace Api.Modules.Grids.Services
 
         private static void BuildGridSchema(DataTable dataTable, GridSettingsAndDataModel results, bool hasPredefinedColumns)
         {
-            string[] editableFields = results.Editable.Fields;
+            string[] editableFields = results.Editable.Fields ?? Array.Empty<string>();
             
             foreach (DataColumn dataColumn in dataTable.Columns)
             {

--- a/Api/Modules/Modules/Controllers/ModulesController.cs
+++ b/Api/Modules/Modules/Controllers/ModulesController.cs
@@ -99,6 +99,17 @@ namespace Api.Modules.Modules.Controllers
         {
             return (await modulesService.UpdateSettingsAsync(id, (ClaimsIdentity) User.Identity, moduleSettingsModel)).GetHttpResponseMessage();
         }
+        
+        /// <summary>
+        /// Updates a specific item through a module grid view.
+        /// </summary>
+        [HttpPut]
+        [Route("{id:int}/{itemId:int}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateField(int id, int itemId, Dictionary<string, string> parameters)
+        {
+            return (await modulesService.UpdateField(id, itemId, parameters, (ClaimsIdentity) User.Identity)).GetHttpResponseMessage();
+        }
 
         /// <summary>
         /// Creates a new Wiser module.

--- a/Api/Modules/Modules/Interfaces/IModulesService.cs
+++ b/Api/Modules/Modules/Interfaces/IModulesService.cs
@@ -81,5 +81,15 @@ namespace Api.Modules.Modules.Interfaces
         /// <param name="identity">The identity of the authenticated user.</param>
         /// <param name="id">The ID of the module.</param>
         Task<ServiceResult<bool>> DeleteAsync(ClaimsIdentity identity, int id);
+        
+        /// <summary>
+        /// Updates a field in a module grid view.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="itemId"></param>
+        /// <param name="parameters"></param>
+        /// <param name="identity"></param>
+        /// <returns></returns>
+        public Task<ServiceResult<bool>> UpdateField(int id, int itemId, Dictionary<string, string> parameters, ClaimsIdentity identity);
     }
 }

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -474,11 +474,21 @@ export class Grids {
 
                             window.processing.removeProcess(process);
                         },
-                        update: async function(options) {
+                        update: async options => {
                             const data = options.data;
+                            const moduleId = this.base.settings.moduleId;
+                            const itemId = data.id;
+
+                            const results = await Wiser.api({
+                                method: 'PUT',
+                                url: `${dynamicItems.settings.wiserApiRoot}modules/${encodeURIComponent(moduleId)}/${encodeURIComponent(itemId)}`,
+                                contentType: 'application/json',
+                                data: JSON.stringify(data)
+                            });
                             
-                            // TODO: 1. Make an API call that runs a query associated to this module with the data of `data`.
-                            //       2. Refresh the overview. Run the datasource read function.
+                            options.success(results);
+
+                            this.mainGrid.dataSource.read();
                         }
                     },
                     schema: {
@@ -486,6 +496,11 @@ export class Grids {
                         total: "totalResults",
                         model: gridDataResult.schemaModel
                     }
+                },
+                save: function (event) {
+                    event.sender.one("dataBound", function () {
+                        event.sender.dataSource.read();
+                    });
                 },
                 editable: {
                     mode: "incell"

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -405,6 +405,7 @@ export class Grids {
             let filtersChanged = false;
             const finalGridViewSettings = $.extend(true, {
                 dataSource: {
+                    autoSync: true,
                     serverPaging: !usingDataSelector && !gridViewSettings.clientSidePaging,
                     serverSorting: !usingDataSelector && !gridViewSettings.clientSideSorting,
                     serverFiltering: !usingDataSelector && !gridViewSettings.clientSideFiltering,
@@ -472,6 +473,12 @@ export class Grids {
                             }
 
                             window.processing.removeProcess(process);
+                        },
+                        update: async function(options) {
+                            const data = options.data;
+                            
+                            // TODO: 1. Make an API call that runs a query associated to this module with the data of `data`.
+                            //       2. Refresh the overview. Run the datasource read function.
                         }
                     },
                     schema: {
@@ -479,6 +486,9 @@ export class Grids {
                         total: "totalResults",
                         model: gridDataResult.schemaModel
                     }
+                },
+                editable: {
+                    mode: "incell"
                 },
                 excel: {
                     fileName: "Module Export.xlsx",


### PR DESCRIPTION
Adds a feature where module gridviews can be edited directly. By default this feature is disabled, and has to be enabled through the module's options. A new property in the `gridViewSettings` has been introduced to define the editable fields in a grid view of a module. This consists of an array of field names that can be edited, and a query ID that is ran after editing a field's value. The query is populated with all of the fields of the row of the field that is edited.

Setting up the options goes as follows:
```
"editable": {
   "fields": [
      "title",
      "phone_number",
      "first_name",
      "last_name"
   ],
   "queryId": 100201
}
```