### PR TITLE
chore/editable-module-grid-fields-rename-refactor

### DIFF
--- a/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
+++ b/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
@@ -70,13 +70,13 @@ namespace Api.Modules.Grids.Models
         public string LanguageCode { get; set; }
         
         /// <summary>
-        /// Gets or sets the definitions of editable fields within the module.
+        /// Gets or sets the definitions of triggerable fields within the module.
         /// </summary>
-        public EditableFieldModel Editable { get; set; }
+        public TriggerableFieldModel Triggerable { get; set; }
 
         public GridSettingsAndDataModel()
         {
-            Editable = new EditableFieldModel();
+            Triggerable = new TriggerableFieldModel();
         }
     }
 }

--- a/Api/Modules/Grids/Models/TriggerableFieldModel.cs
+++ b/Api/Modules/Grids/Models/TriggerableFieldModel.cs
@@ -1,0 +1,17 @@
+namespace Api.Modules.Grids.Models;
+
+/// <summary>
+/// A model that defines triggerable fields from a module.
+/// </summary>
+public class TriggerableFieldModel
+{
+    /// <summary>
+    /// The names of the fields that are triggerable.
+    /// </summary>
+    public string[] Fields { get; set; }
+    
+    /// <summary>
+    /// The query ID from the <c>wiser_query</c> table to execute once the field is updated.
+    /// </summary>
+    public int QueryId { get; set; }
+}

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2297,7 +2297,7 @@ namespace Api.Modules.Grids.Services
 
         private static void BuildGridSchema(DataTable dataTable, GridSettingsAndDataModel results, bool hasPredefinedColumns)
         {
-            string[] editableFields = results.Editable.Fields ?? Array.Empty<string>();
+            string[] triggerableFields = results.Triggerable.Fields ?? Array.Empty<string>();
             
             foreach (DataColumn dataColumn in dataTable.Columns)
             {
@@ -2338,11 +2338,11 @@ namespace Api.Modules.Grids.Services
                 {
                     kendoColumnType = null;
                 }
-
+                
                 bool editableField = 
-                    editableFields.Contains(dataColumn.ColumnName) &&
+                    triggerableFields.Contains(dataColumn.ColumnName) &&
                     !dataColumn.ColumnName.Equals("id", StringComparison.OrdinalIgnoreCase);
-
+                
                 results.SchemaModel.Fields.Add(fieldName,
                     new FieldModel
                     {


### PR DESCRIPTION
Renamed the property that defines triggerable fields to run a query when editing "in cell" fields in a grid in a module. This is to avoid a conflict with the "editable" property reserved by Kendo UI.