### PR TITLE
fix/action-button-visiblity-check-after-selected-lines-reselection

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -866,6 +866,9 @@ export class Fields {
                     const selectedRowUids = gridData.filter(row => selectedIds.includes(row.id)).map(row => row.uid);
                     const selectedRows = $(gridSelector).find(selectedRowUids.map(uid => `tr[data-uid="${uid}"]`).join(','));
                     grids.mainGrid.select(selectedRows);
+                    
+                    // Force a 'change' event trigger to check the conditions for each action button's visiblity.
+                    grids.mainGrid.trigger('change');
                 }
             }
 


### PR DESCRIPTION
Fixes a bug where the visiblity of action buttons were not checked upon reselecting earlier selected lines
