### PR TITLE
fix/inline-module-editing-for-sub-entity-grids

### DIFF
--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2338,9 +2338,12 @@ namespace Api.Modules.Grids.Services
                 {
                     kendoColumnType = null;
                 }
+
+                bool kendoEditableField =
+                    results.Columns.Find(column => column.Field == dataColumn.ColumnName)?.Editable ?? false;
                 
                 bool editableField = 
-                    triggerableFields.Contains(dataColumn.ColumnName) &&
+                    (triggerableFields.Contains(dataColumn.ColumnName) || kendoEditableField) &&
                     !dataColumn.ColumnName.Equals("id", StringComparison.OrdinalIgnoreCase);
                 
                 results.SchemaModel.Fields.Add(fieldName,


### PR DESCRIPTION
Fixed a bug where sub entities grids would incorrectly check whether they are editable or not.
