### PR TITLE
Feature/initial server side sorting

### DIFF
--- a/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
+++ b/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
@@ -77,7 +77,7 @@ namespace Api.Modules.Grids.Models
         /// <summary>
         /// A list of columns to sort by using server side sorting.
         /// </summary>
-        public string[] Sort { get; set; }
+        public GridSortModel[] Sort { get; set; }
 
         public GridSettingsAndDataModel()
         {

--- a/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
+++ b/Api/Modules/Grids/Models/GridSettingsAndDataModel.cs
@@ -73,6 +73,11 @@ namespace Api.Modules.Grids.Models
         /// Gets or sets the definitions of triggerable fields within the module.
         /// </summary>
         public TriggerableFieldModel Triggerable { get; set; }
+        
+        /// <summary>
+        /// A list of columns to sort by using server side sorting.
+        /// </summary>
+        public string[] Sort { get; set; }
 
         public GridSettingsAndDataModel()
         {

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -1730,7 +1730,7 @@ namespace Api.Modules.Grids.Services
 
             string defaultSort = null;
             if (results.Sort != null)
-                defaultSort = $"ORDER BY {string.Join(", ", results.Sort)}";
+                defaultSort = $"ORDER BY {string.Join(", ", results.Sort.Select(sort => $"`{sort.Field}` {sort.Dir}"))}";
             
             (selectQuery, countQuery) = BuildGridQueries(options, selectQuery, countQuery, identity, defaultSort, moduleSettingsModel.FieldMappings);
 

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -1727,7 +1727,12 @@ namespace Api.Modules.Grids.Services
 
             var userId = IdentityHelpers.GetWiserUserId(identity);
             clientDatabaseConnection.AddParameter("userId", userId);
-            (selectQuery, countQuery) = BuildGridQueries(options, selectQuery, countQuery, identity, null, moduleSettingsModel.FieldMappings);
+
+            string defaultSort = null;
+            if (results.Sort != null)
+                defaultSort = $"ORDER BY {string.Join(", ", results.Sort)}";
+            
+            (selectQuery, countQuery) = BuildGridQueries(options, selectQuery, countQuery, identity, defaultSort, moduleSettingsModel.FieldMappings);
 
             // Get the count, but only if this is not the first load.
             if (!results.ClientSidePaging && !String.IsNullOrWhiteSpace(countQuery) && (options?.FirstLoad ?? true))

--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2171,7 +2171,12 @@ namespace Api.Modules.Grids.Services
 
             clientDatabaseConnection.ClearParameters();
             clientDatabaseConnection.AddParameter("itemId", itemId);
-            (selectQuery, countQuery) = BuildGridQueries(options, selectQuery, countQuery, identity, "");
+            
+            string defaultSort = null;
+            if (results.Sort != null)
+                defaultSort = $"ORDER BY {string.Join(", ", results.Sort.Select(sort => $"`{sort.Field}` {sort.Dir}"))}";
+            
+            (selectQuery, countQuery) = BuildGridQueries(options, selectQuery, countQuery, identity, defaultSort);
 
             // Get the count, but only if this is not the first load.
             if ((options?.FirstLoad ?? true) && !String.IsNullOrWhiteSpace(countQuery))


### PR DESCRIPTION
This pull request adds an option to grid overviews and sub entity grids to customize the initial sorting that is applied to queries upon loading the grids. For queries using the `{sort}` placeholder, you can now set an initial sorting by changing the grid settings by using the `sort` property. This property holds an array of objects that define the field and the direction of the sorting. An example can be found below.

`options` column in `wiser_entityproperty` on sub entity grids: 
```
{
	"sort": [
		{
			"field": "added_on",
			"dir": "DESC"
		},
                {
			"field": "title",
			"dir": "ASC"
		}
	],
	...
```

`options` column in `wiser_modules` for module grids:
```
{		
	"gridViewSettings": {
		"sort": [
		       {
				"field": "added_on",
				"dir": "DESC"
		       },
		       {
				"field": "title",
				"dir": "ASC"
		       }
		],
        },
        ...
}
```
