### PR TITLE
fix/remove-link-when-using-prefixed-tables

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -2020,9 +2020,10 @@ const moduleSettings = {
          * @param {string} sourceId The ID of the item that you want to link.
          * @param {string} destinationId The ID of the item that you want to link to.
          * @param {number} linkTypeNumber The link type number.
+         * @param {string|null} sourceEntityType The entity type name of the source ID.
          * @returns {Promise} A promise with the result of the AJAX call.
          */
-        async removeItemLink(sourceId, destinationId, linkTypeNumber) {
+        async removeItemLink(sourceId, destinationId, linkTypeNumber, sourceEntityType = null) {
             return Wiser.api({
                 url: `${this.base.settings.wiserApiRoot}items/remove-links?moduleId=${this.base.settings.moduleId}`,
                 method: "DELETE",
@@ -2030,7 +2031,8 @@ const moduleSettings = {
                 data: JSON.stringify({
                     encryptedSourceIds: [sourceId],
                     encryptedDestinationIds: [destinationId],
-                    linkType: linkTypeNumber
+                    linkType: linkTypeNumber,
+                    sourceEntityType: sourceEntityType
                 })
             });
         }

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1582,7 +1582,13 @@ export class Grids {
 
                     const destinationItemId = dataItem.encryptedDestinationItemId || dataItem.encrypted_destination_item_id || senderGrid.element.closest(".item").data("itemIdEncrypted");
                     const linkType = dataItem.linkTypeNumber || dataItem.link_type_number || dataItem.linktypenumber || dataItem.linkType || dataItem.link_type || dataItem.linktype;
-                    await this.base.removeItemLink(options.currentItemIsSourceId ? destinationItemId : encryptedId, options.currentItemIsSourceId ? encryptedId : destinationItemId, linkType);
+                    
+                    await this.base.removeItemLink(
+                        options.currentItemIsSourceId ? destinationItemId : encryptedId,
+                        options.currentItemIsSourceId ? encryptedId : destinationItemId,
+                        linkType,
+                        options.entityType ?? null);
+                    
                     senderGrid.dataSource.read();
                     break;
                 }


### PR DESCRIPTION
Fixed a bug where links on prefixed tables were not correctly removed due to the inability of determining the table prefix if no entity type was passed to the service method.
