### PR TITLE
fix/module-overviews-always-editable-if-not-specified

### DIFF
--- a/Api/Modules/Grids/Services/GridsService.cs
+++ b/Api/Modules/Grids/Services/GridsService.cs
@@ -2307,7 +2307,7 @@ namespace Api.Modules.Grids.Services
 
         private static void BuildGridSchema(DataTable dataTable, GridSettingsAndDataModel results, bool hasPredefinedColumns)
         {
-            string[] triggerableFields = results.Triggerable.Fields ?? Array.Empty<string>();
+            string[] triggerableFields = results.Triggerable.Fields;
             
             foreach (DataColumn dataColumn in dataTable.Columns)
             {
@@ -2349,10 +2349,7 @@ namespace Api.Modules.Grids.Services
                     kendoColumnType = null;
                 }
 
-                bool isEditable = (
-                                      triggerableFields.Length == 0 ||
-                                      triggerableFields.Contains(dataColumn.ColumnName)
-                                    ) &&
+                bool isEditable = (triggerableFields?.Contains(dataColumn.ColumnName) ?? true) &&
                                   !dataColumn.ColumnName.Equals("id", StringComparison.OrdinalIgnoreCase);
                 
                 results.SchemaModel.Fields.Add(fieldName,

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -375,6 +375,18 @@ export class Grids {
             // Delete properties that we have already defined, so that they won't be overwritten again by the $.extend below.
             delete gridViewSettings.filterable;
             delete gridViewSettings.toolbar;
+            
+            // Setup the editable property.
+            let editable = false;
+            if (gridViewSettings.readonly === true) {
+                editable = false;
+            } else if (gridViewSettings.editable) {
+                editable = gridViewSettings.editable;
+            } else if (gridViewSettings.triggerable) {
+                editable = {
+                    mode: "incell"
+                };
+            }
 
             let columns = gridViewSettings.columns || [];
             if (columns) {
@@ -502,9 +514,7 @@ export class Grids {
                         event.sender.dataSource.read();
                     });
                 },
-                editable: {
-                    mode: "incell"
-                },
+                editable: editable,
                 excel: {
                     fileName: "Module Export.xlsx",
                     filterable: true,


### PR DESCRIPTION
Simplified the schema model condition for the ability of editing and set the edit ability in the front end of a grid based on conditions, the same as sub-entity grids.