### PR TITLE
Fix/inial table creation fixes

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -414,6 +414,7 @@ CREATE TABLE IF NOT EXISTS `wiser_module`  (
   `type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT 'DynamicItems',
   `group` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
   `custom_script` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
+  `is_fullscreen` TINYINT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 

--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -218,8 +218,6 @@ CREATE TABLE IF NOT EXISTS `wiser_itemdetail`  (
   `groupname` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `key` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
   `value` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
-  `value_as_int` bigint GENERATED ALWAYS AS (CAST(`value` AS SIGNED)) VIRTUAL NULL,
-  `value_as_decimal` decimal(65,30) GENERATED ALWAYS AS (CAST(`value` AS DECIMAL(65,30))) VIRTUAL NULL,
   `long_value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `item_key`(`item_id`, `key`, `language_code`) USING BTREE,


### PR DESCRIPTION
("inial" should be "initial". Small typo there).

This change fixes two issues related to the initial creation of the tables using the `npm run setup:mysql` command:

1. An issue has been fixed where the `wiser_module` table was missing a required column "is_fullscreen".
2. An issue has been fixed where unused value columns were removed from `wiser_itemdetail` causing non-strict database servers to throw errors.