### PR TITLE
chore/optional-auto-refresh-after-inline-edit

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -487,8 +487,6 @@ export class Grids {
                             });
                             
                             options.success(results);
-
-                            this.mainGrid.dataSource.read();
                         }
                     },
                     schema: {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -401,6 +401,9 @@ export class Grids {
                     });
                 }
             }
+            
+            // Forced auto-refresh setting. Default value is 'true'.
+            const refreshAfterInlineEdit = gridViewSettings.refreshGridAfterInlineEdit ?? true;
 
             let filtersChanged = false;
             const finalGridViewSettings = $.extend(true, {
@@ -496,9 +499,11 @@ export class Grids {
                     }
                 },
                 save: function (event) {
-                    event.sender.one("dataBound", function () {
-                        event.sender.dataSource.read();
-                    });
+                    if (refreshAfterInlineEdit) {
+                        event.sender.one("dataBound", function () {
+                            event.sender.dataSource.read();
+                        });
+                    }
                 },
                 editable: {
                     mode: "incell"


### PR DESCRIPTION
Added an optional option to disable the auto-refresh upon making a change to a grid/sub-entities grid field.