### PR TITLE
feature/auto-collapsable-grid-groups

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -528,6 +528,14 @@ export class Grids {
                     if (gridViewSettings.keepFiltersState !== false && filtersChanged) {
                         await this.saveGridViewFiltersState(`main_grid_filters_${this.base.settings.moduleId}`, event.sender);
                     }
+                    
+                    // Auto-collapse groups if enabled.
+                    if(gridViewSettings.collapseGroups) {
+                        const grid = event.sender.element.data('kendoGrid');
+                        event.sender.element.find(`.k-grouping-row`).each(function(groupEvent) {
+                            grid.collapseGroup(this);
+                        })
+                    }
                 },
                 change: this.onGridSelectionChange.bind(this),
                 resizable: true,


### PR DESCRIPTION
Added an option in the grid view settings to automatically collapse all groups. The option is called `collapseGroups` in the gridview settings. By default it is disabled.