### PR TITLE
feature/hidden-delete-button-when-disallowed

### DIFF
--- a/Api/Modules/Items/Models/ItemMetaDataModel.cs
+++ b/Api/Modules/Items/Models/ItemMetaDataModel.cs
@@ -96,5 +96,10 @@ namespace Api.Modules.Items.Models
         /// Gets or sets whether the user is allowed to delete items in this module.
         /// </summary>
         public bool CanDelete { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the delete action of the entity.
+        /// </summary>
+        public string DeleteAction { get; set; }
     }
 }

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -1889,7 +1889,8 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                             item.changed_by,
                             permission.id AS permissionId,
                             permission.permissions,
-                            IFNULL(entity.enable_multiple_environments, 0) AS enable_multiple_environments
+                            IFNULL(entity.enable_multiple_environments, 0) AS enable_multiple_environments,
+                            entity.delete_action AS `delete_action`
                         FROM {tablePrefix}{WiserTableNames.WiserItem}{{0}} AS item
                         LEFT JOIN {WiserTableNames.WiserEntity} AS entity ON entity.name = item.entity_type AND entity.module_id = item.moduleid
 
@@ -1935,6 +1936,7 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
             result.ChangedOn = dataTable.Rows[0].Field<DateTime?>("changed_on");
             result.ChangedBy = dataTable.Rows[0].Field<string>("changed_by");
             result.EnableMultipleEnvironments = Convert.ToBoolean(dataTable.Rows[0]["enable_multiple_environments"]);
+            result.DeleteAction = dataTable.Rows[0].Field<string>("delete_action");
 
             return new ServiceResult<ItemMetaDataModel>(result);
         }

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -1954,8 +1954,11 @@ const moduleSettings = {
                 }
 
                 editMenu.find(".copyToEnvironment").closest("li").toggle(itemMetaData.enableMultipleEnvironments > 0);
-                deleteButtons.toggle(itemMetaData.canDelete && !itemMetaData.removed);
-                undeleteButtons.toggle(itemMetaData.canDelete && !!itemMetaData.removed); // Double exclamation mark, because jQuery expects a true/false, but removed has a 0 or 1 most of the time.
+
+                const canDelete = itemMetaData.canDelete && !itemMetaData.removed && itemMetaData.deleteAction !== 'disallow' && itemMetaData.readOnly === 'Nee';
+                const canUndelete = itemMetaData.canDelete && !!itemMetaData.removed && itemMetaData.readOnly === 'Nee';
+                deleteButtons.toggle(canDelete);
+                undeleteButtons.toggle(canUndelete);
 
                 $("#alert-first").addClass("hidden");
 

--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -318,6 +318,11 @@ export class Windows {
                             this.base.dialogs.copyItemToEnvironmentDialog.element.data("currentItemWindow", currentItemWindow);
                             this.base.dialogs.copyItemToEnvironmentDialog.open();
                         });
+                        
+                        const canDelete = itemMetaData.canDelete && !itemMetaData.removed && itemMetaData.deleteAction !== 'disallow' && itemMetaData.readOnly === 'Nee';
+                        const canUndelete = itemMetaData.canDelete && itemMetaData.removed && itemMetaData.readOnly === 'Nee';
+                        currentItemWindow.wrapper.find(".k-i-verwijderen").parent().toggleClass("hidden", !canDelete);
+                        currentItemWindow.element.find(".editMenu .undeleteItem").closest("li").toggleClass("hidden", !canUndelete);
                     });
 
                     // Get the information that we need about the opened item.
@@ -348,8 +353,6 @@ export class Windows {
                     // Handle access rights.
                     currentItemWindow.wrapper.find(".itemNameField").prop("readonly", !htmlData.canWrite).prop("disabled", !htmlData.canWrite);
                     currentItemWindow.wrapper.find(".saveButton").toggleClass("hidden", !htmlData.canWrite);
-                    currentItemWindow.wrapper.find(".k-i-verwijderen").parent().toggleClass("hidden", !htmlData.canDelete);
-                    currentItemWindow.element.find(".editMenu .undeleteItem").closest("li").toggleClass("hidden", !htmlData.canDelete);
 
                     // Add all fields and tabs to the window.
                     let genericTabHasFields = false;


### PR DESCRIPTION
Hides delete buttons if the item is either readonly, the "canDelete"  option is false, or if the entity's delete action of the item is set to "disallow".
