### PR TITLE
chore/remove-edit-suffix-in-item-window

### DIFF
--- a/Api/Modules/Items/FieldTemplates/HTMLeditor.js
+++ b/Api/Modules/Items/FieldTemplates/HTMLeditor.js
@@ -247,7 +247,7 @@
                     height: "600px",
                     minHeight: "300px",
                     minWidth: "300px",
-                    title: "{title} bewerken",
+                    title: "{title}",
                     modal: true,
                     actions: ["Minimize", "Maximize"],
                     open: (openEvent) => {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -254,7 +254,7 @@ export class Windows {
                 windowTitle = title
             }
 
-            windowTitle = !windowTitle ? "" : ` &quot;${windowTitle}&quot; <strong> bewerken</strong>`;
+            windowTitle = !windowTitle ? "" : `${windowTitle}`;
             currentItemWindow.title({
                 text: `<button type='button' class='btn btn-cancel'><ins class='icon-line-exit'></ins><span>Annuleren</span></button>${windowTitle}`,
                 encoded: false


### PR DESCRIPTION
Removed unwanted "bewerken" suffix as window title for items.
