### PR TITLE
Feature/topol mail editor

### DIFF
--- a/Api/Modules/Items/FieldTemplates/mail-editor.html
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.html
@@ -1,4 +1,4 @@
-<div style="{style}">
+<div id="container_{propertyIdWithSuffix}" style="{style}">
     <div class="item">
         <h4 class="{titleClass}">
             <label for="field_{propertyIdWithSuffix}">{title}</label>
@@ -7,7 +7,12 @@
         </span>
         </h4>
     </div>
-    <div id="field_{propertyIdWithSuffix}_container" style="width: {width}%; height: {height}px;"></div>
+    <div class="custom-templates-container">
+        <select class="load-custom-template">
+        </select>
+        <div class="form-hint" style="margin-top: 4px;">Selecteer een template om in te laden in de onderstaande editor. <b>Pas op!</b> Dit zal de huidige template vervangen.</div>
+    </div>
+    <div id="field_{propertyIdWithSuffix}_container" style="width: {width}%; height: {height}px; margin-top: 8px;"></div>
     <input
         id="field_{propertyIdWithSuffix}_html"
         class="item"

--- a/Api/Modules/Items/FieldTemplates/mail-editor.html
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.html
@@ -10,9 +10,9 @@
     <div class="custom-templates-container">
         <select class="load-custom-template">
         </select>
-        <div class="form-hint" style="margin-top: 4px;">Selecteer een template om in te laden in de onderstaande editor. <b>Pas op!</b> Dit zal de huidige template vervangen.</div>
+        <div class="form-hint">Selecteer een template om in te laden in de onderstaande editor. <b>Pas op!</b> Dit zal de huidige template vervangen.</div>
     </div>
-    <div id="field_{propertyIdWithSuffix}_container" style="width: {width}%; height: {height}px; margin-top: 8px;"></div>
+    <div id="field_{propertyIdWithSuffix}_container" style="width: {width}%; height: {height}px; margin-top: 10px;"></div>
     <input
         id="field_{propertyIdWithSuffix}_html"
         class="item"

--- a/Api/Modules/Items/FieldTemplates/mail-editor.js
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.js
@@ -136,6 +136,22 @@
                 
                 const htmlField = $('#field_{propertyIdWithSuffix}_html');
                 htmlField.val(encodeHtml(html));
+            },
+            async onTestSend(email, json, html) {
+                await Wiser.api({
+                    method: 'POST',
+                    contentType: 'application/json',
+                    url: `${dynamicItems.settings.wiserApiRoot}topol/send-test-mail`,
+                    data: JSON.stringify({
+                        email: email,
+                        html: html
+                    })
+                });
+                
+                Wiser.showMessage({
+                    title: 'Test mail verzenden',
+                    content: 'Test mail succesvol verzonden!'
+                });
             }
         },
         // Default settings.

--- a/Api/Modules/Topol/Controllers/TopolController.cs
+++ b/Api/Modules/Topol/Controllers/TopolController.cs
@@ -78,4 +78,12 @@ public class TopolController : ControllerBase
             url = fileUrl
         });
     }
+
+    [HttpPost("send-test-mail")]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> SendTestMail(SendTestMailRequest request)
+    {
+        await topolService.SendTestMail(request.Email, request.Html);
+        return Ok();
+    }
 }

--- a/Api/Modules/Topol/Controllers/TopolController.cs
+++ b/Api/Modules/Topol/Controllers/TopolController.cs
@@ -1,11 +1,9 @@
 using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Core.Helpers;
 using Api.Modules.Topol.Interfaces;
 using Api.Modules.Topol.Models;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Modules.Topol.Controllers;
@@ -19,6 +17,13 @@ public class TopolController : ControllerBase
     public TopolController(ITopolService topolService)
     {
         this.topolService = topolService;
+    }
+
+    [HttpGet("{encryptedId}")]
+    public async Task<IActionResult> GetTemplate(string encryptedId)
+    {
+        TopolTemplate template = await topolService.GetTemplate(encryptedId, User.Identity as ClaimsIdentity);
+        return new JsonResult(template);
     }
 
     [HttpGet("folders")]

--- a/Api/Modules/Topol/Interfaces/ITopolService.cs
+++ b/Api/Modules/Topol/Interfaces/ITopolService.cs
@@ -17,4 +17,6 @@ public interface ITopolService
     public Task<int> DeleteImagesOrFolders(ImageDeleteModel[] models, string identifier);
 
     public Task<string> UploadImage(IFormFile image, string path, string identifier);
+
+    public Task SendTestMail(string email, string html);
 }

--- a/Api/Modules/Topol/Interfaces/ITopolService.cs
+++ b/Api/Modules/Topol/Interfaces/ITopolService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Api.Modules.Topol.Models;
 using Microsoft.AspNetCore.Http;
@@ -7,6 +8,8 @@ namespace Api.Modules.Topol.Interfaces;
 
 public interface ITopolService
 {
+    public Task<TopolTemplate> GetTemplate(string encryptedId, ClaimsIdentity identity);
+    
     public Task<Image[]> GetFolders(string path, string identifier, string baseUrl, string subDomain);
 
     public Task<string[]> InsertFolder(string name, string path, string identifier);

--- a/Api/Modules/Topol/Models/SendTestMailRequest.cs
+++ b/Api/Modules/Topol/Models/SendTestMailRequest.cs
@@ -1,0 +1,8 @@
+namespace Api.Modules.Topol.Models;
+
+public class SendTestMailRequest
+{
+    public string Email { get; set; }
+    
+    public string Html { get; set; }
+}

--- a/Api/Modules/Topol/Models/TopolTemplate.cs
+++ b/Api/Modules/Topol/Models/TopolTemplate.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json.Linq;
+
+namespace Api.Modules.Topol.Models;
+
+public class TopolTemplate
+{
+    public ulong Id { get; set; }
+    
+    public string Title { get; set; }
+    
+    public JObject Json { get; set; }
+    
+    public string Html { get; set; }
+}

--- a/Api/Modules/Topol/Services/TopolService.cs
+++ b/Api/Modules/Topol/Services/TopolService.cs
@@ -2,15 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
+using System.Security.Claims;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Api.Core.Helpers;
+using Api.Modules.Tenants.Interfaces;
 using Api.Modules.Topol.Enums;
 using Api.Modules.Topol.Interfaces;
 using Api.Modules.Topol.Models;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Exceptions;
+using GeeksCoreLibrary.Core.Interfaces;
+using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
 
 namespace Api.Modules.Topol.Services;
 
@@ -18,9 +23,39 @@ public class TopolService : ITopolService, IScopedService
 {
     private readonly IDatabaseConnection databaseConnection;
 
-    public TopolService(IDatabaseConnection databaseConnection)
+    private readonly IWiserTenantsService wiserTenantsService;
+
+    private readonly IWiserItemsService wiserItemsService;
+
+    public TopolService(
+	    IDatabaseConnection databaseConnection,
+	    IWiserTenantsService wiserTenantsService,
+	    IWiserItemsService wiserItemsService
+	    )
     {
         this.databaseConnection = databaseConnection;
+        this.wiserTenantsService = wiserTenantsService;
+        this.wiserItemsService = wiserItemsService;
+    }
+
+    public async Task<TopolTemplate> GetTemplate(string encryptedId, ClaimsIdentity identity)
+    {
+	    ulong templateId = await wiserTenantsService.DecryptValue<ulong>(encryptedId, identity);
+
+	    WiserItemModel templateItem = await wiserItemsService.GetItemDetailsAsync(templateId, skipPermissionsCheck: true);
+	    
+	    string jsonString = templateItem.GetDetailValue("mail_template");
+	    JObject json = !string.IsNullOrEmpty(jsonString) ? JObject.Parse(jsonString) : null;
+	    
+	    string html = templateItem.GetDetailValue("mail_template_html");
+
+	    return new TopolTemplate
+	    {
+		    Id = templateId,
+		    Title = templateItem.Title,
+		    Json = json,
+		    Html = html
+	    };
     }
     
     public async Task<Image[]> GetFolders(string path, string identifier, string baseUrl, string subDomain)

--- a/Api/Modules/Topol/Services/TopolService.cs
+++ b/Api/Modules/Topol/Services/TopolService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
 using System.Security.Claims;
-using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Api.Modules.Tenants.Interfaces;
 using Api.Modules.Topol.Enums;
@@ -13,6 +12,7 @@ using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Exceptions;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.Communication.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json.Linq;
@@ -27,15 +27,19 @@ public class TopolService : ITopolService, IScopedService
 
     private readonly IWiserItemsService wiserItemsService;
 
+    private readonly ICommunicationsService communicationsService;
+
     public TopolService(
 	    IDatabaseConnection databaseConnection,
 	    IWiserTenantsService wiserTenantsService,
-	    IWiserItemsService wiserItemsService
+	    IWiserItemsService wiserItemsService,
+	    ICommunicationsService communicationsService
 	    )
     {
         this.databaseConnection = databaseConnection;
         this.wiserTenantsService = wiserTenantsService;
         this.wiserItemsService = wiserItemsService;
+        this.communicationsService = communicationsService;
     }
 
     public async Task<TopolTemplate> GetTemplate(string encryptedId, ClaimsIdentity identity)
@@ -348,5 +352,11 @@ SELECT item_id AS `item_id`, ordering AS `ordering` FROM wiser_itemfile WHERE id
 	    await itemIdReader.CloseAsync();
 	    
 	    return $"/api/v3/items/{itemId}/files/file/{image.FileName}?ordering={ordering}";
+    }
+
+    public async Task SendTestMail(string email, string html)
+    {
+	    string subject = "Coder - Test mail";
+	    await communicationsService.SendEmailAsync(email, subject, html);
     }
 }

--- a/Api/appsettings.json
+++ b/Api/appsettings.json
@@ -27,7 +27,7 @@
     "BaseUrl": "https://api.wiser3.nl",
     "MaximumLoginAttemptsForUsers": 25,
     "MaximumLoginAttemptsForAdmins": 25,
-    "JsonPropertiesToAlwaysEncrypt": [ "dataSelectorId", "queryId", "countQueryId", "emailDataQueryId", "preRequestQueryId", "resourcesQueryId", "resources1QueryId", "resources2QueryId", "resources3QueryId", "postRequestQueryId", "contentItemId", "initialItemId", "newItemParentId", "linkItemsQueryId", "linkItemsCountQueryId", "executeQueryAfterEmail", "parentId", "deleteItemQueryId", "defaultValueQueryId", "editQuery", "availabilityUrlQuery", "identifierQueryId" ],
+    "JsonPropertiesToAlwaysEncrypt": [ "dataSelectorId", "queryId", "countQueryId", "emailDataQueryId", "preRequestQueryId", "resourcesQueryId", "resources1QueryId", "resources2QueryId", "resources3QueryId", "postRequestQueryId", "contentItemId", "initialItemId", "newItemParentId", "linkItemsQueryId", "linkItemsCountQueryId", "executeQueryAfterEmail", "parentId", "deleteItemQueryId", "defaultValueQueryId", "editQuery", "availabilityUrlQuery", "identifierQueryId", "loadCustomTemplatesQueryId" ],
     "MainSubDomain": "main",
     "UseTerserForTemplateScriptMinification": false
   },

--- a/Api/appsettings.json
+++ b/Api/appsettings.json
@@ -27,7 +27,7 @@
     "BaseUrl": "https://api.wiser3.nl",
     "MaximumLoginAttemptsForUsers": 25,
     "MaximumLoginAttemptsForAdmins": 25,
-    "JsonPropertiesToAlwaysEncrypt": [ "dataSelectorId", "queryId", "countQueryId", "emailDataQueryId", "preRequestQueryId", "resourcesQueryId", "resources1QueryId", "resources2QueryId", "resources3QueryId", "postRequestQueryId", "contentItemId", "initialItemId", "newItemParentId", "linkItemsQueryId", "linkItemsCountQueryId", "executeQueryAfterEmail", "parentId", "deleteItemQueryId", "defaultValueQueryId", "editQuery", "availabilityUrlQuery", "identifierQueryId", "loadCustomTemplatesQueryId" ],
+    "JsonPropertiesToAlwaysEncrypt": [ "dataSelectorId", "queryId", "countQueryId", "emailDataQueryId", "preRequestQueryId", "resourcesQueryId", "resources1QueryId", "resources2QueryId", "resources3QueryId", "postRequestQueryId", "contentItemId", "initialItemId", "newItemParentId", "linkItemsQueryId", "linkItemsCountQueryId", "executeQueryAfterEmail", "parentId", "deleteItemQueryId", "defaultValueQueryId", "editQuery", "availabilityUrlQuery", "identifierQueryId", "loadCustomTemplatesQueryId", "mergeTagsQueryId" ],
     "MainSubDomain": "main",
     "UseTerserForTemplateScriptMinification": false
   },

--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -521,6 +521,31 @@ export class Windows {
                 return;
             }
 
+            // Check if the item has a Topol instance running.
+            if(TopolPlugin.iframe && document.body.contains(TopolPlugin.iframe)) {
+                // Since manually saving the Topol instance runs async, but the 'save' function does not have the ability to wait,
+                // we wait manually by waiting for a success message that comes back from the iframe of the Topol instance.
+                await new Promise(resolve => {
+                    // Handle the message event handler.
+                    function messageHandler(event) {
+                        if (event.origin !== 'https://d5aoblv5p04cg.cloudfront.net')
+                            return;
+
+                        const data = event.data;
+                        if (data && data.action === 'onSave') {
+                            window.removeEventListener('message', messageHandler);
+                            resolve(data);
+                        }
+                    }
+
+                    // Attach the message listener to the window.
+                    window.addEventListener('message', messageHandler);
+
+                    // Release the JSON and HTML of the Topol mail editor iframe into their respective input fields.
+                    TopolPlugin.save();
+                });
+            }
+
             const data = kendoWindow.element.data();
             const titleField = popupWindowContainer.find(".itemNameField");
             const newTitle = titleField.val();


### PR DESCRIPTION
Adds the following changes:

- The ability to load custom templates from a query.
- Fixed a bug where Topol mail editors would not correctly be saved for popup items, through sub-entity grids.
- The ability to set up merge tags based on a query.
- The ability to send test mails through the Topol mail editor.