### PR TITLE
feature/topol-mail-editor

### DIFF
--- a/Api/Modules/Items/FieldTemplates/mail-editor.html
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.html
@@ -7,7 +7,7 @@
         </span>
         </h4>
     </div>
-    <div class="custom-templates-container">
+    <div class="custom-templates-container item" data-property-name="{propertyName}_custom_template">
         <select class="load-custom-template">
         </select>
         <div class="form-hint">Selecteer een template om in te laden in de onderstaande editor. <b>Pas op!</b> Dit zal de huidige template vervangen.</div>


### PR DESCRIPTION
Fixed a bug where an error would appear because of the expected HTML not to be set up correctly for the mail editor field template.
