### PR TITLE
fix/is-fullscreen-initial-query-character-set-syntax-error-fix

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTables.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTables.sql
@@ -406,7 +406,7 @@ CREATE TABLE IF NOT EXISTS `wiser_module`  (
   `type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT 'DynamicItems',
   `group` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
   `custom_script` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
-  `is_fullscreen` TINYINT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 0,
+  `is_fullscreen` TINYINT NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
 


### PR DESCRIPTION
Fixes a MySQL syntax error when defining the 'is_fullscreen' column by removing the need to assign a character set.
