### PR TITLE
fix/column-settings-overwritten-for-sub-entity-grids

### DIFF
--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -877,7 +877,7 @@ async function generateGrid(data, model, columns) {
     kendoGridOptions.editable = editable;
     kendoGridOptions.selectable = hideCheckboxColumn ? options.selectable : false;
     kendoGridOptions.toolbar = toolbar.length === 0 ? null : toolbar;
-    kendoGridOptions.columns = columns;
+    kendoGridOptions.columns = $.extend(true, kendoGridOptions.columns, columns);
 
     await window.dynamicItems.grids.loadGridViewColumnsState("sub_entities_grid_columns_{propertyId}", kendoGridOptions);
     if (kendoGridOptions.keepFiltersState !== false) {


### PR DESCRIPTION
Fixed a bug where the columns settings for a Kendo Grid in sub-entities-grid would be overwritten with other settings than the ones set up in the options column in wiser_entity_property.