### PR TITLE
fix/default-value-for-multiline-input-type

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -1704,6 +1704,10 @@ export class Fields {
                                         dialog.element.find("input").kendoUpload(uploadOptions);
                                         break;
                                     }
+                                case 'multiline':
+                                    if (options.defaultValue)
+                                        dialog.element.find("textarea").val(options.defaultValue);
+                                    break;
                                 default:
                                     if (options.defaultValue) {
                                         dialog.element.find("input").val(options.defaultValue);


### PR DESCRIPTION
Fixed a bug where the default value would incorrectly be populated in the textarea element.