### PR TITLE
fix/topol-discarded-on-different-tab

### DIFF
--- a/Api/Modules/Items/FieldTemplates/mail-editor.html
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.html
@@ -7,7 +7,7 @@
         </span>
         </h4>
     </div>
-    <div class="loading loader">
+    <div class="loader">
         <div class="loader-icon">
             <div></div>
             <div></div>
@@ -23,14 +23,14 @@
     <div id="field_{propertyIdWithSuffix}_container" style="width: {width}%; height: {height}px; margin-top: 10px;"></div>
     <input
         id="field_{propertyIdWithSuffix}_html"
-        class="item"
+        class="item mail-editor-input-field"
         name="{propertyName}_html"
         type="hidden"
         data-html-encoded="true"
         data-property-name="{propertyName}_html">
     <input
         id="field_{propertyIdWithSuffix}"
-        class="item"
+        class="item mail-editor-input-field"
         name="{propertyName}"
         type="hidden"
         data-property-name="{propertyName}">

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -24,7 +24,7 @@ export class Fields {
         this.base = base;
         this.dependencies = {};
         this.fieldInitializers = {};
-        this.fieldSelector = "select:not(:disabled,[readonly]), input:not(:disabled,[readonly]), [data-kendo-control], textarea:not(:disabled,[readonly])";
+        this.fieldSelector = `select:not(:disabled,[readonly]), input:not(:disabled,[readonly]):not(.mail-editor-input-field), input.mail-editor-input-field:not(:disabled,[readonly])[value]:not([value=""]), [data-kendo-control], textarea:not(:disabled,[readonly])`;
         this.originalItemValues = {};
         this.unsavedItemValues = {};
     }


### PR DESCRIPTION
Fixes a bug where if the topol mail editor was on another tab and the tab was never visited, the item detail of the editor's value would be deleted in the database.