### PR TITLE
fix/auto-translate-in-item

### DIFF
--- a/Api/Modules/Google/Services/GoogleTranslateService.cs
+++ b/Api/Modules/Google/Services/GoogleTranslateService.cs
@@ -81,7 +81,7 @@ public class GoogleTranslateService : IGoogleTranslateService, IScopedService
         var client = TranslationClient.CreateFromApiKey(googleSettings.TranslationsApiKey);
 
         //client.Service.HttpClient.DefaultRequestHeaders.Referrer = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor.HttpContext);
-        client.Service.HttpClient.DefaultRequestHeaders.Referrer = new Uri("https://wiserdemo.wiser3.nl");
+        client.Service.HttpClient.DefaultRequestHeaders.Referrer = new Uri("https://api.coder.nl");
         return client;
     }
 }


### PR DESCRIPTION
Fixes a bug where the Google Translate API would throw an error upon automatically translating text in an item.