### PR TITLE
fix/topol-free-templates-only

### DIFF
--- a/Api/Modules/Items/FieldTemplates/mail-editor.js
+++ b/Api/Modules/Items/FieldTemplates/mail-editor.js
@@ -138,7 +138,8 @@
         // API overwrites.
         api: {
             FOLDERS: '{baseUrl}/api/v3/topol/folders',
-            IMAGE_UPLOAD: '{baseUrl}/api/v3/topol/image-upload'
+            IMAGE_UPLOAD: '{baseUrl}/api/v3/topol/image-upload',
+            PREMADE_TEMPLATES: 'https://app.topol.io/api/premade-templates?type=FREE'
         },
         // Callbacks.
         callbacks: {
@@ -170,6 +171,7 @@
         language: 'nl',
         removeTopBar: true,
         showUnsavedDialogBeforeExit: false,
+        premadeTemplates: true,
         // Dynamic settings.
         mergeTags: mergeTags
     };


### PR DESCRIPTION
This change overwrites the Topol mail editor API request for retrieving predefined templates to only include free templates, rather than the inclusion of pro templates.