### PR TITLE
fix/check-on-unsupported-input-to-check-caps-lock-state

### DIFF
--- a/FrontEnd/Core/Scripts/components/login.js
+++ b/FrontEnd/Core/Scripts/components/login.js
@@ -160,6 +160,9 @@ export default {
         },
 
         checkCapslock(e) {
+            if(typeof e.getModifierState !== 'function')
+                return;
+            
             this.loginForm.capslock = e.getModifierState('CapsLock');
         }
     }


### PR DESCRIPTION
Added a check to see if the browser supports the input to get the caps lock state.
