### PR TITLE
fix/template-login-roles-not-retained

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -1533,6 +1533,9 @@ const moduleSettings = {
                 }
             }).data("kendoMultiSelect");
 
+            // Set the selected login roles.
+            this.userRolesDropDown.value(this.templateSettings.loginRoles);
+
             // Save the current settings so that we can keep track of any changes and warn the user if they're about to leave without saving.
             this.initialTemplateSettings = this.getCurrentTemplateSettings();
         }


### PR DESCRIPTION
Fixes an issue where the role selector to indicate what roles could execute the query template was not auto-filled.
