### PR TITLE
feature/file-upload-no-selection-support

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -1682,7 +1682,7 @@ export class Fields {
                                         await require("@progress/kendo-ui/js/kendo.upload.js");
                                         let itemId;
                                         let itemLinkId;
-                                        if (selectedItems) {
+                                        if (selectedItems?.length > 0) {
                                             if (selectedItems.length > 1) {
                                                 kendo.alert("Het uploaden van bestanden kan maar met 1 item tegelijk.");
                                                 break;
@@ -1696,10 +1696,19 @@ export class Fields {
                                             itemId = mainItemDetails.encryptedId || mainItemDetails.encrypted_id || mainItemDetails.encryptedid || this.base.settings.zeroEncrypted;
                                             itemLinkId = mainItemDetails.linkId || mainItemDetails.link_id || 0;
                                         }
+                                        
+                                        // Determine the property name of the file to be uploaded in wiser_itemfile.
+                                        // If no selection was made, and the action was set up to do not require a
+                                        // selection (default = false), the internal property name
+                                        // "TEMPORARY_FILE_FROM_CODER" will be used.
+                                        // This mean the user will handle the file further using follow-up queries.
+                                        const propertyName = selectedItems?.length >= 1 && (!options.allowNoSelection || false)
+                                            ? options.propertyName
+                                            : 'TEMPORARY_FILE_FROM_CODER';
 
                                         const uploadOptions = $.extend(true, {
                                             async: {
-                                                saveUrl: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/upload?propertyName=${encodeURIComponent(options.propertyName)}&itemLinkId=${itemLinkId}`,
+                                                saveUrl: `${this.base.settings.wiserApiRoot}items/${encodeURIComponent(itemId)}/upload?propertyName=${encodeURIComponent(propertyName)}&itemLinkId=${itemLinkId}`,
                                                 removeUrl: "remove",
                                                 withCredentials: false
                                             },


### PR DESCRIPTION
Allows the user parameter type of fileupload to run with a temporary file if no selection is made.

If no selection is made, and the user parameter's options has `allowNoSelection: true`, then the property name of the uploaded file will be "TEMPORARY_FILE_FROM_CODER". This will allow Coder to process the file upload further and return a wiser_itemfile ID of the inserted item.

Further explanation in-code:
![image](https://github.com/user-attachments/assets/5c177943-9451-48f0-aa41-1138040004ae)

