### PR TITLE
fix/restore-role-dropdown-values-only-when-applicable

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/Templates.js
+++ b/FrontEnd/Modules/Templates/Scripts/Templates.js
@@ -1533,8 +1533,8 @@ const moduleSettings = {
                 }
             }).data("kendoMultiSelect");
 
-            // Set the selected login roles.
-            this.userRolesDropDown.value(this.templateSettings.loginRoles);
+            // Set the selected login roles if the dropdown exists.
+            this.userRolesDropDown?.value(this.templateSettings.loginRoles);
 
             // Save the current settings so that we can keep track of any changes and warn the user if they're about to leave without saving.
             this.initialTemplateSettings = this.getCurrentTemplateSettings();


### PR DESCRIPTION
Fixed a bug where the setting the role values for the dropdown for templates would be undefined and throw an error for template types that do not have this dropdown
