### PR TITLE
fix/cms-settings-visibility-based-on-component-mode

### DIFF
--- a/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
+++ b/FrontEnd/Modules/Templates/Scripts/DynamicContent.js
@@ -277,8 +277,6 @@ const moduleSettings = {
 
             try {
                 this.selectedComponentData.component = newComponent;
-                await this.reloadComponentModes(newComponent, newComponentMode);
-                this.selectedComponentData.componentMode = this.componentModeComboBox.text();
 
                 const response = await Wiser.api({
                     url: `/Modules/DynamicContent/${encodeURIComponent(newComponent)}/DynamicContentTabPane`,
@@ -291,6 +289,9 @@ const moduleSettings = {
                 this.initializeDynamicKendoComponents();
                 await this.transformCodeMirrorViews();
                 this.initBindings();
+
+                await this.reloadComponentModes(newComponent, newComponentMode);
+                this.selectedComponentData.componentMode = this.componentModeComboBox.text();
             } catch (exception) {
                 console.error(exception);
                 kendo.alert("Er is iets fout gegaan. Probeer het a.u.b. opnieuw");


### PR DESCRIPTION
This pull request fixes two bugs that are related to showing/hiding fields in dynamic content:

1. Fixed a bug where the selected value was incorrectly parsed into a component mode to show/hide relevant fields.
2. Fixed a bug where the fields were all visible when initially opening dynamic content.
