### PR TITLE
fix/parent-item-id-link-with-combobox

### DIFF
--- a/Api/Modules/Items/FieldTemplates/multiselect.html
+++ b/Api/Modules/Items/FieldTemplates/multiselect.html
@@ -24,12 +24,15 @@
             <ins class="icon-info-full"></ins>
         </span>
     </h4>
-    <div class="flex-container">
+    <div class="flex-container" style="{fieldContainerStyle}">
         <select id="field_{propertyIdWithSuffix}" name="{propertyName}_{languageCode}" data-kendo-control="kendoMultiSelect"
                 class="multi-select" multiple="multiple" placeholder="Maak uw keuze..." data-placeholder="Maak uw keuze..."
                 {required} pattern="{pattern}" data-lpignore="true">
         </select>
         <button class="hidden newItemButton"></button>
+    </div>
+    <div class="flex-container" style="{fieldErrorContainerStyle}">
+        {fieldErrorMessage}
     </div>
     <div class="form-hint {formHintClass}">{hint}</div>
 </div>

--- a/Api/Modules/Items/Services/ItemsService.cs
+++ b/Api/Modules/Items/Services/ItemsService.cs
@@ -1501,6 +1501,9 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                 var extraAttributes = "";
                 var containerCss = dataRow.Field<string>("css") ?? "";
                 var elementCss = "";
+                var fieldContainerCss = "";
+                var fieldErrorContainerCss = "";
+                var fieldErrorMessage = "";
                 var inputType = GclCoreConstants.DefaultInputType;
 
                 // Setup any extra attributes.
@@ -1658,20 +1661,58 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                     var linkTypeNumber = optionsObject.Value<int>("linkTypeNumber");
                     var limit = fieldType.Equals("combobox") ? "LIMIT 1" : "";
                     var linkTablePrefixForSaving = await wiserItemsService.GetTablePrefixForLinkAsync(linkTypeNumber);
+                    var linkSettings = linkTypeNumber > 0 ? await wiserItemsService.GetLinkTypeSettingsAsync(linkTypeNumber) : new LinkSettingsModel();
 
-                    var linkValueQuery = $@"SELECT {(currentItemIsDestinationId ? "item_id" : "destination_item_id")} AS result
-                                            FROM {linkTablePrefixForSaving}{WiserTableNames.WiserItemLink} 
-                                            WHERE {(currentItemIsDestinationId ? "destination_item_id" : "item_id")} = ?itemId 
-                                            AND type = ?linkTypeNumber
-                                            {limit}";
+                    if (fieldType.Equals("multiselect", StringComparison.OrdinalIgnoreCase) && currentItemIsDestinationId && linkSettings.UseItemParentId)
+                    {
+                        // Impossible combination.
+                        fieldContainerCss = "display: none;";
+                        fieldErrorMessage = "Het is niet mogelijk om een multiselect veld te gebruiken met de huidige instellingen.";
+                    }
+                    else
+                    {
+                        fieldErrorContainerCss = "display: none;";
+                        fieldErrorMessage = "";
+                    }
+
+                    string linkValueQuery;
+
+                    if (linkSettings.UseItemParentId)
+                    {
+                        linkValueQuery = $"""
+                                          SELECT {(currentItemIsDestinationId ? "id" : "parent_item_id")} AS result
+                                          FROM {linkTablePrefixForSaving}{WiserTableNames.WiserItem}
+                                          WHERE {(currentItemIsDestinationId ? "parent_item_id" : "id")} = ?itemId AND entity_type = ?entityType
+                                          {limit}
+                                          """;
+                    }
+                    else
+                    {
+                        linkValueQuery = $"""
+                                          SELECT {(currentItemIsDestinationId ? "item_id" : "destination_item_id")} AS result
+                                          FROM {linkTablePrefixForSaving}{WiserTableNames.WiserItemLink} 
+                                          WHERE {(currentItemIsDestinationId ? "destination_item_id" : "item_id")} = ?itemId 
+                                          AND type = ?linkTypeNumber
+                                          {limit}
+                                          """;
+                    }
 
                     clientDatabaseConnection.ClearParameters();
                     clientDatabaseConnection.AddParameter("itemId", itemId);
                     clientDatabaseConnection.AddParameter("linkTypeNumber", linkTypeNumber);
+                    clientDatabaseConnection.AddParameter("entityType", currentItemIsDestinationId ? linkSettings.SourceEntityType : linkSettings.DestinationEntityType);
                     dataTable = await clientDatabaseConnection.GetAsync(linkValueQuery);
                     if (dataTable.Rows.Count > 0)
                     {
-                        var values = dataTable.Rows.Cast<DataRow>().Select(linkedItemDataRow => linkedItemDataRow.Field<long>("result").ToString()).ToList();
+                        var rawValues = dataTable.Rows.Cast<DataRow>().Select(linkedItemDataRow => linkedItemDataRow["result"].ToString()).ToList();
+                        var values = new List<ulong>();
+                        foreach (var rawValue in rawValues)
+                        {
+                            if (UInt64.TryParse(rawValue, out var parsedValue))
+                            {
+                                values.Add(parsedValue);
+                            }
+                        }
 
                         defaultValue = String.Join(",", values);
                     }
@@ -1740,7 +1781,11 @@ DELETE FROM {linkTablePrefix}{WiserTableNames.WiserItemLink} AS link WHERE (link
                         .Replace("{extraAttribute}", extraAttributes)
                         .Replace("{itemId}", itemId.ToString())
                         .Replace("{style}", containerCss)
+                        .Replace("{fieldContainerStyle}", fieldContainerCss)
+                        .Replace("{fieldErrorContainerStyle}", fieldErrorContainerCss)
+                        .Replace("{style}", containerCss)
                         .Replace("{elementStyle}", elementCss)
+                        .Replace("{fieldErrorMessage}", fieldErrorMessage)
                         .Replace("{itemIdEncrypted}", encryptedId.Replace(" ", "+"))
                         .Replace("{dependsOnField}", dataRow.Field<string>("depends_on_field") ?? "")
                         .Replace("{dependsOnOperator}", dataRow.Field<string>("depends_on_operator") ?? "")


### PR DESCRIPTION
Fixed some parent ID issues.

A combobox that saves its value as a link on a link type that has "UseItemParentId" enabled would not retrieve its value properly. This is now fixed.

In addition, setting "currentItemIsDestinationId" to true for a multiselect in conjunction with "UseItemParentId" is now an invalid combination and will show an error.
