### PR TITLE
feature/action-button-visibility-based-on-read-only

### DIFF
--- a/Api/Modules/Items/FieldTemplates/action-button.js
+++ b/Api/Modules/Items/FieldTemplates/action-button.js
@@ -23,5 +23,12 @@
         field.find(".originalText").html(options.text);
     }
     const kendoComponent = field.kendoButton(options).data("kendoButton");
+    
+    // Hide the action button if the item is set to be read-only and the "show-on-read-only" is false.
+    const showOnReadOnly = options.showOnReadOnly !== undefined ? options.showOnReadOnly : true;
+    debugger;
+    if(!showOnReadOnly && {readonly})
+        field.closest('.item').hide();
+    
     {customScript}
 })();

--- a/Api/Modules/Items/FieldTemplates/action-button.js
+++ b/Api/Modules/Items/FieldTemplates/action-button.js
@@ -1,13 +1,18 @@
 ﻿(() => {
     const field = $("#field_{propertyIdWithSuffix}");
     const userItemPermissions = {userItemPermissions};
+    const encryptedItemId = '{itemIdEncrypted}';
+    const entityType = '{entityType}';
+    const propertyId = {propertyId};
+    const readOnly = {readonly};
+    let options = {options};
     
-    const options = $.extend({
+    options = $.extend({
         click: (event) => {
-            window.dynamicItems.fields.onActionButtonClick(event, "{itemIdEncrypted}", {propertyId}, {options}, field); 
+            window.dynamicItems.fields.onActionButtonClick(event, encryptedItemId, propertyId, options, field); 
         },
         icon: "gear"
-    }, {options});
+    }, options);
 
     if (options.doesCreate && (userItemPermissions & window.dynamicItems.permissionsEnum.create) === 0) {
         options.enable = false;
@@ -26,8 +31,9 @@
     
     // Hide the action button if the item is set to be read-only and the "show-on-read-only" is false.
     const showOnReadOnly = options.showOnReadOnly !== undefined ? options.showOnReadOnly : true;
-    debugger;
-    if(!showOnReadOnly && {readonly})
+
+    // Hide the item if it should not be visible if it is read-only.
+    if(!showOnReadOnly && readOnly)
         field.closest('.item').hide();
     
     {customScript}

--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -776,7 +776,7 @@ async function generateGrid(data, model, columns) {
         },
         dataBound: async (event) => {
             // To hide toolbar buttons that require a row to be selected.
-            dynamicItems.grids.onGridSelectionChange(event);
+            dynamicItems.grids.onGridSelectionChange(event, readonly);
 
             // Save the filters
             if (kendoGridOptions.keepFiltersState !== false && filtersChanged) {
@@ -871,7 +871,7 @@ async function generateGrid(data, model, columns) {
             }
         },
         filter: (event) => {filtersChanged = true;},
-        change: dynamicItems.grids.onGridSelectionChange.bind(dynamicItems.grids)
+        change: event => dynamicItems.grids.onGridSelectionChange.bind(dynamicItems.grids, event, readonly)
     }, options);
 
     kendoGridOptions.editable = editable;

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1228,6 +1228,9 @@ export class Grids {
                 ? `data-roles="${Misc.encodeHtml(rolesAttributeValue)}"`
                 : '';
             
+            const showOnReadOnlyValue = customAction.showOnReadOnly !== undefined ? customAction.showOnReadOnly : true;
+            const showOnReadOnlyAttribute = `data-show-on-read-only="${Misc.encodeHtml(showOnReadOnlyValue)}"`
+            
             const minimumRows = customAction.minimumRows;
             const minimumRowsAttribute = minimumRows
                 ? `data-minimum-rows=${minimumRows}`
@@ -1240,7 +1243,9 @@ export class Grids {
             
             const selector = gridSelector.replace(/#/g, "\\#");
             
-            const { condition, roles, ...customActionData } = customAction;
+            const { condition, roles, showOnReadOnly, ...customActionData } = customAction;
+            
+            const defaultAttributes = `${conditionAttribute} ${rolesAttribute} ${showOnReadOnlyAttribute} ${minimumRowsAttribute} ${maximumRowsAttribute}`;
             
             if (customAction.groupName) {
                 let group = groups.filter(g => g.name === customAction.groupName)[0];
@@ -1254,12 +1259,12 @@ export class Grids {
                     groups.push(group);
                 }
                 
-                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} ${rolesAttribute} ${minimumRowsAttribute} ${maximumRowsAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
+                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${defaultAttributes} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
             } else {
                 actionsWithoutGroups.push({
                     name: `customAction${i.toString()}`,
                     text: customAction.text,
-                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} ${rolesAttribute} ${minimumRowsAttribute} ${maximumRowsAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
+                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${defaultAttributes} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
                 });
             }
         }
@@ -1735,6 +1740,7 @@ export class Grids {
             const button = $(this);
             const condition = button.data('condition');
             const roles = button.data('roles');
+            const showOnReadOnly = button.data('show-on-read-only');
             const minimumRows = button.data('minimum-rows') ?? 0;
             const maximumRows = button.data('maximum-rows') ?? Number.MAX_VALUE;
             
@@ -1775,6 +1781,11 @@ export class Grids {
                 // Check whether the user's role is required by the action button.
                 const rolesArray = roles.split(',');
                 shouldHide = !rolesArray.includes(userRole);
+            }
+            
+            // Check whether any of the selected rows is set to be read-only.
+            if(!shouldHide && !showOnReadOnly) {
+                debugger;
             }
             
             // Check whether the user has selected more or less than the allowed rows selected of the action button.


### PR DESCRIPTION
Implemented the ability for action buttons to be visible/hidden based on whether they are supposed to be hidden if the item is marked to be read-only. This works both for action buttons as an entity property, in sub-entity-grids, and in grid modules.

The new action button property "showOnReadOnly" will base the visibility of the button if the item is read-only.

For grid modules, if you wish to mark an item to be read-only, the custom_query of the module needs to have an additional column named "read_only". The boolean value of this column will then determine whether the item/row in the grid view is read-only or not. Then, action buttons using the "showOnReadOnly" property will dynamically change their visibility based on the selected rows.