### PR TITLE
fix/modules-visible-from-previous-login

### DIFF
--- a/FrontEnd/Core/Scripts/main.js
+++ b/FrontEnd/Core/Scripts/main.js
@@ -33,6 +33,7 @@ import {
     CLEAR_LOCAL_TOTP_BACKUP_CODES,
     CLOSE_ALL_MODULES,
     CLOSE_MODULE,
+    CLEAR_ALL_MODULES,
     CREATE_BRANCH,
     CREATE_BRANCH_ERROR,
     DELETE_BRANCH,
@@ -711,6 +712,7 @@ class Main {
                     // Update the user's active time one last time.
                     await this.$store.dispatch(UPDATE_ACTIVE_TIME);
                     this.$store.dispatch(CLOSE_ALL_MODULES);
+                    this.$store.dispatch(CLEAR_ALL_MODULES);
                     await this.$store.dispatch(AUTH_LOGOUT);
                 },
 

--- a/FrontEnd/Core/Scripts/store/index.js
+++ b/FrontEnd/Core/Scripts/store/index.js
@@ -20,6 +20,7 @@ import {
     CLEAR_LOCAL_TOTP_BACKUP_CODES,
     CLOSE_ALL_MODULES,
     CLOSE_MODULE,
+    CLEAR_ALL_MODULES,
     CREATE_BRANCH,
     CREATE_BRANCH_ERROR,
     CREATE_BRANCH_SUCCESS,
@@ -306,6 +307,9 @@ const loginModule = {
                 await this.dispatch(START_UPDATE_TIME_ACTIVE_TIMER);
             }
             
+            // Reload the modules after a succesful login.
+            await this.dispatch(MODULES_REQUEST);
+            
             // Load system styling.
             await Misc.injectSystemStyling();
         },
@@ -492,6 +496,10 @@ const modulesModule = {
             state.activeModule = null;
             state.openedModules = [];
         },
+        [CLEAR_ALL_MODULES]: (state) => {
+            state.allModules = [];
+            state.moduleGroups = [];
+        },
         [TOGGLE_PIN_MODULE]: (state, moduleId) => {
             const module = state.allModules.filter(m => m.moduleId === moduleId)[0];
 
@@ -612,6 +620,10 @@ const modulesModule = {
 
         [CLOSE_ALL_MODULES]({ commit }) {
             commit(CLOSE_ALL_MODULES);
+        },
+
+        [CLEAR_ALL_MODULES]({ commit }) {
+            commit(CLEAR_ALL_MODULES);
         },
 
         async [TOGGLE_PIN_MODULE]({ commit, state }, moduleId) {

--- a/FrontEnd/Core/Scripts/store/mutation-types.js
+++ b/FrontEnd/Core/Scripts/store/mutation-types.js
@@ -24,6 +24,7 @@ export const MODULES_LOADED = "modulesLoaded";
 export const OPEN_MODULE = "openModule";
 export const CLOSE_MODULE = "closeModule";
 export const CLOSE_ALL_MODULES = "closeAllModules";
+export const CLEAR_ALL_MODULES = "clearAllModules";
 export const ACTIVATE_MODULE = "activateModule";
 export const TOGGLE_PIN_MODULE = "togglePinModule";
 


### PR DESCRIPTION
Fixed a bug where the modules of a previous login would still be visible and only be loaded correctly upon a refresh.
