### PR TITLE
chore/kendo-update-2025.2.702 (corrected colors and alt table row styling)

### DIFF
--- a/FrontEnd/Modules/Base/Css/kendo.custom.css
+++ b/FrontEnd/Modules/Base/Css/kendo.custom.css
@@ -494,6 +494,10 @@ td.k-group-cell,
     background-color: var(--lightest-color) !important;
 }
 
+.k-table-alt-row:hover {
+    background-color: color-mix(in srgb, var(--kendo-color-on-app-surface, #1D1B20) 8%, transparent) !important;
+}
+
 .k-pivot-rowheaders .k-alt .k-alt,
 .k-header.k-alt {
     background-color: #dedede;

--- a/FrontEnd/Modules/Base/Css/variables.css
+++ b/FrontEnd/Modules/Base/Css/variables.css
@@ -75,4 +75,15 @@
 
 	--kendo-font-size: 14px;
 	--kendo-spacing-3: 0.5rem;
-	}
+	
+	--kendo-color-base: #fff;
+	--kendo-color-base-hover: #e1e1e1;
+	--kendo-color-base-active: #d7d7d7;
+	--kendo-color-base-subtle: #e1e1e1;
+	--kendo-color-base-subtle-hover: #d7d7d7;
+	--kendo-color-subtle: #e1e1e1;
+	--kendo-color-subtle-hover: #d7d7d7;
+	--kendo-color-surface: #fff;
+	--kendo-color-primary-on-surface: #000;
+	--kendo-color-primary: #1EAA8FFF;
+}


### PR DESCRIPTION
Corrected colors so they align with the original and fixed a visual bug with hovering over alt table rows.
