### PR TITLE
feature/responsive-image-zoom

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Css/DynamicItems.css
+++ b/FrontEnd/Modules/DynamicItems/Css/DynamicItems.css
@@ -449,3 +449,15 @@ body.iframe .editMenu {
 .k-svg-icon > svg {
     width: inherit;
 }
+
+#imageDialog:has(> img) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#imageDialog > img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}

--- a/FrontEnd/Modules/DynamicItems/Css/DynamicItems.css
+++ b/FrontEnd/Modules/DynamicItems/Css/DynamicItems.css
@@ -450,14 +450,24 @@ body.iframe .editMenu {
     width: inherit;
 }
 
-#imageDialog:has(> img) {
+#imageDialog img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+#imageDialog > .image-zoom-container {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+    cursor: zoom-in;
+
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
-#imageDialog > img {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
+#imageDialog > .image-zoom-container.zoomed {
+    cursor: zoom-out;
 }

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -430,7 +430,7 @@ const moduleSettings = {
                     dialog = dialogElement.kendoDialog({
                         title: "Afbeelding",
                         closable: true,
-                        modal: false,
+                        modal: true,
                         resizable: true
                     }).data("kendoDialog");
                 }

--- a/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/DynamicItems.js
@@ -434,8 +434,48 @@ const moduleSettings = {
                         resizable: true
                     }).data("kendoDialog");
                 }
+                
+                // Make a clone of the image element for the popup window.
+                const imageClone = image.clone();
+                
+                // Create a zoom container element.
+                const imageZoomContainer = $('<div class="image-zoom-container"></div>');
+                imageZoomContainer.append(imageClone);
+                
+                // Keep a state of the zoom.
+                let imageZoomed = false;
+                
+                // Add a click event on the image clone to zoom in/out on the image.
+                imageZoomContainer.click(() => {
+                    imageZoomed = !imageZoomed;
+                    
+                    imageZoomContainer.toggleClass('zoomed');
+                    
+                    if(!imageZoomed) {
+                        imageClone.css({
+                            transform: 'scale(1)',
+                            'transform-origin': 'center center'
+                        });
+                    }
+                });
+                
+                // Add a mouse over event for handling the offset of the zoomed image.
+                imageZoomContainer.on('mousemove', function(event) {
+                    if(!imageZoomed)
+                        return;
 
-                dialog.content(image.clone());
+                    const offset = imageZoomContainer.offset();
+                    const x = ((event.pageX - offset.left) / imageZoomContainer.width()) * 100;
+                    const y = ((event.pageY - offset.top) / imageZoomContainer.height()) * 100;
+
+                    imageClone.css({
+                        transform: 'scale(2)',
+                        'transform-origin': `${x}% ${y}%`,
+                    });
+                });
+                
+                // Set the content of the dialog and open it.
+                dialog.content(imageZoomContainer.get());
                 dialog.open();
             });
 


### PR DESCRIPTION
Afbeelding wordt initieel geladen met zijn originele grootte. Als de afbeelding te groot is, wordt hij tot de maximale grootte van het scherm gebracht.

Je kan de afbeelding nogmaals klikken om de originele grootte te tonen. Door te hoveren over de afbeelding, kan je de afbeelding analyseren. Op basis van waar de muis zich bevindt, zoom je in op dat punt.

Kleinere afbeeldingen hebben dezelfde werking, maar hebben een minder grote toegevoegde waarde.