### PR TITLE
fix/incorrectly-escaped-link-button-html

### DIFF
--- a/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
+++ b/Api/Modules/Items/FieldTemplates/sub-entities-grid.js
@@ -281,10 +281,12 @@
         }
     
         if (!readonly && options.entityType && (!options.toolbar || !options.toolbar.hideLinkButton)) {
+            const escapedOptions = JSON.stringify(options).replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+            
             toolbar.push({
                 name: "link",
                 text: "Koppelen",
-                template: "<a class='k-button k-button-icontext' onclick='return window.dynamicItems.grids.onLinkSubEntityClick(\"{itemIdEncrypted}\", {itemId}, \"{entityType}\", \"" + options.entityType + "\", \"\\#overviewGrid{propertyIdWithSuffix}\", \"" + (options.linkTypeNumber || "") + "\", " + (options.hideIdColumn || false) + ", " + (options.hideLinkIdColumn || false) + ", " + (options.hideTypeColumn || false) + ", " + (options.hideEnvironmentColumn || false) + ", " + (options.hideTitleColumn || false) + ", {propertyId}, \"" + JSON.stringify(options).replace(/"/g, '\\"') + "\")'><span class='k-font-icon k-i-link-horizontal'></span>" + window.dynamicItems.getEntityTypeFriendlyName(options.entityType) + " koppelen</a>"
+                template: `<a class='k-button k-button-icontext' onclick='return window.dynamicItems.grids.onLinkSubEntityClick("{itemIdEncrypted}", {itemId}, "{entityType}", "${options.entityType}", "\\#overviewGrid{propertyIdWithSuffix}", "${options.linkTypeNumber || ""}", ${options.hideIdColumn || false}, ${options.hideLinkIdColumn || false}, ${options.hideTypeColumn || false}, ${options.hideEnvironmentColumn || false}, ${options.hideTitleColumn}, {propertyId}, ${escapedOptions})'><span class='k-font-icon k-i-link-horizontal'></span>${window.dynamicItems.getEntityTypeFriendlyName(options.entityType)} koppelen</a>`
             });
         }
     

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1449,7 +1449,12 @@ export class Grids {
      */
     onLinkSubEntityClick(encryptedParentId, plainParentId, currentEntityType, entityType, senderGridSelector, linkTypeNumber, hideIdColumn, hideLinkIdColumn, hideTypeColumn, hideEnvironmentColumn, hideTitleColumn, propertyId, gridOptions) {
         linkTypeNumber = linkTypeNumber || "";
+        
         if (typeof gridOptions === "string") {
+            gridOptions = gridOptions
+                .replace(/&quot;/g, '"')
+                .replace(/&apos;/, "'");
+            
             gridOptions = JSON.parse(gridOptions);
         }
 


### PR DESCRIPTION
Fixed a bug where deeply nested single quotes in the JSON passed to the link button's HTML element would be incorrectly escaped.