### PR TITLE
fix/form-validation-on-unloaded-entity-properties

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -593,6 +593,9 @@ export class Fields {
             await this.base.loadKendoScripts(tabFields.script);
             $.globalEval(tabFields.script);
             tabFields.executed = true;
+            
+            // Mark the tab to be loaded.
+            tabContentContainer.data('loaded', true);
 
             this.base.fields.handleAllDependenciesOfContainer(tabContentContainer, tabFields.entityType, tabName, windowId);
         } catch (exception) {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -219,7 +219,14 @@ export class Windows {
                 validateOnBlur: false,
                 rules: {
                     required: (input) => {
+                        // Check if the input is a required property.
                         if (input.prop("required") && !input.closest(".item").hasClass("dependency-hidden")) {
+                            // Skip validation on fields that were not loaded and are not new.
+                            // Since they weren't loaded in the first place, we know they haven't been changed.
+                            if(!input.closest('.k-tabstrip-content')?.data('loaded') && !isNewItem)
+                                return true;
+                            
+                            // Validate the value.
                             return $.trim(input.val()) !== "";
                         }
 


### PR DESCRIPTION
Fixed a bug where validation would incorrectly be applied to unloaded properties.