### PR TITLE
fix/add-image-in-file-manager-not-loading

### DIFF
--- a/FrontEnd/Modules/FileManager/Scripts/FileManager.js
+++ b/FrontEnd/Modules/FileManager/Scripts/FileManager.js
@@ -17,7 +17,7 @@ require("@progress/kendo-ui/js/kendo.window.js");
 require("@progress/kendo-ui/js/kendo.numerictextbox.js");
 require("@progress/kendo-ui/js/kendo.dropdownlist.js");
 require("@progress/kendo-ui/js/kendo.tabstrip.js");
-// require("@progress/kendo-ui/js/filemanager/contextmenu.js");
+require("@progress/kendo-ui/js/kendo.filemanager.js");
 require("@progress/kendo-ui/js/cultures/kendo.culture.nl-NL.js");
 require("@progress/kendo-ui/js/messages/kendo.messages.nl-NL.js");
 


### PR DESCRIPTION
Fixed a bug where a required Kendo subpackage was missing for the file manager to load.