### PR TITLE
fix/sub-entities-grid-pagination-invisible-for-safari

### DIFF
--- a/FrontEnd/Modules/Base/Css/masterpage.css
+++ b/FrontEnd/Modules/Base/Css/masterpage.css
@@ -1259,14 +1259,6 @@ footer input ~ .meta-data li.meta-toggle label span:last-child {
 	height: auto;
 }
 
-.k-window-content > .pane-content .k-tabstrip .dynamicTabContent .gridview:nth-child(2),
-.k-window-content > .pane-content .k-tabstrip .dynamicTabContent script ~ .gridview:nth-child(3) {
-	height: 100%;
-	max-height: calc(100% - 138px);
-	display: flex;
-	flex-direction: column;
-}
-
 .k-window-content > .pane-content .k-tabstrip .dynamicTabContent script ~ .gridview:nth-child(3) .k-grid {
 	flex-basis: 100%;
 	display: flex;


### PR DESCRIPTION
Removed unnecessary styling that would affect overflowing issues on Safari browsers.