### PR TITLE
Template version number selection is now reversed

### DIFF
--- a/Api/Modules/Templates/Helpers/PublishedEnvironmentHelper.cs
+++ b/Api/Modules/Templates/Helpers/PublishedEnvironmentHelper.cs
@@ -46,7 +46,6 @@ namespace Api.Modules.Templates.Helpers
             }
 
             var versionList = new List<int>(versionsAndPublished.Keys);
-            versionList = versionList.OrderBy(v => v).ToList();
 
             return new PublishedEnvironmentModel
             {

--- a/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
+++ b/Api/Modules/Templates/Services/DataLayer/TemplateDataService.cs
@@ -194,7 +194,7 @@ LIMIT 1");
         /// <inheritdoc />
         public async Task<Dictionary<int, int>> GetPublishedEnvironmentsAsync(int templateId, TenantModel branch = null)
         {
-            var query = $"SELECT version, published_environment FROM {WiserTableNames.WiserTemplate} WHERE template_id = ?templateId";
+            var query = $"SELECT version, published_environment FROM {WiserTableNames.WiserTemplate} WHERE template_id = ?templateId ORDER BY version DESC";
             DataTable dataTable;
             if (branch != null)
             {


### PR DESCRIPTION
Removed `versionList = versionList.OrderBy(v => v).ToList();`, because it is redundant and made it so that the version numbers now go from high to low rather than low to high