### PR TITLE
Pane will now take up all available space, instead of having a fixed width

### DIFF
--- a/FrontEnd/Modules/Templates/Css/Templates.css
+++ b/FrontEnd/Modules/Templates/Css/Templates.css
@@ -171,6 +171,7 @@
 
 /** TREEVIEW **/
 #right-pane {
+    flex-basis: auto !important;
     width: auto;
     right: 0;
 }


### PR DESCRIPTION
Het probleem was dat de pane waar de data in stond een inline-style had met een fixed value van flex-basis. Dit deed de breedte limiteren van de pane en dat maakte de data slecht leesbaar. Nu neemt de pane altijd zoveel ruimte op als dat het kan.

https://app.asana.com/1/236678296282156/project/1211092049250473/task/1211438491596707?focus=true