### PR TITLE
Query error messages now include the parameters (key/value) that are passed.

### DIFF
--- a/Api/Core/Services/ClientDatabaseConnection.cs
+++ b/Api/Core/Services/ClientDatabaseConnection.cs
@@ -221,8 +221,10 @@ namespace Api.Core.Services
             {
                 if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, invalidOperationException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}. Parameters: {parameters}", query, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, invalidOperationException);
                 }
 
                 await Task.Delay(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
@@ -235,8 +237,14 @@ namespace Api.Core.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, mySqlException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    var safeLogMessage = query
+                        .Replace("{", "{{")
+                        .Replace("}", "}}");
+                    
+                    logger.LogError(mySqlException, "Error trying to run this query: {safeLogMessage}. Parameters: {parameters}", safeLogMessage, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, mySqlException);
                 }
                 
                 // If we're not in a transaction, retry the query if it's a deadlock.
@@ -296,8 +304,10 @@ namespace Api.Core.Services
             {
                 if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, invalidOperationException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}. Parameters: {parameters}", query, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, invalidOperationException);
                 }
 
                 Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
@@ -310,8 +320,14 @@ namespace Api.Core.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, mySqlException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    var safeLogMessage = query
+                        .Replace("{", "{{")
+                        .Replace("}", "}}");
+                    
+                    logger.LogError(mySqlException, "Error trying to run this query: {safeLogMessage}. Parameters: {parameters}", safeLogMessage, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, mySqlException);
                 }
                 
                 // If we're not in a transaction, retry the query if it's a deadlock.
@@ -415,8 +431,10 @@ namespace Api.Core.Services
             {
                 if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, invalidOperationException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    logger.LogError(invalidOperationException, "Error trying to run this query: {query}. Parameters: {parameters}", query, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, invalidOperationException);
                 }
 
                 Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
@@ -429,8 +447,14 @@ namespace Api.Core.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                    throw new GclQueryException("Error trying to run query", query, mySqlException);
+                    var commandParameters = GetCommandParametersForLogging(commandToUse);
+                    
+                    var safeLogMessage = query
+                        .Replace("{", "{{")
+                        .Replace("}", "}}");
+                    
+                    logger.LogError(mySqlException, "Error trying to run this query: {safeLogMessage}. Parameters: {parameters}", safeLogMessage, commandParameters);
+                    throw new GclQueryException($"Error trying to run query. Parameters: {commandParameters}", query, mySqlException);
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
@@ -1024,6 +1048,39 @@ SELECT LAST_INSERT_ID();";
                 await Task.Delay(10);
                 counter++;
             }
+        }
+        
+        /// <summary>
+        /// Builds a readable string containing all command parameters and their values,
+        /// intended for logging and debugging purposes.
+        /// </summary>
+        /// <param name="command">
+        /// The <see cref="MySqlCommand"/> whose parameters should be formatted.
+        /// </param>
+        /// <returns>
+        /// A comma-separated list of parameter name/value pairs. Parameter values that are
+        /// <see langword="null"/> or <see cref="DBNull.Value"/> are written as <c>"NULL"</c>.
+        /// Returns <c>"No parameters"</c> if the command has no parameters.
+        /// </returns>
+        private static string GetCommandParametersForLogging(MySqlCommand command)
+        {
+            if (command?.Parameters == null || command.Parameters.Count == 0)
+            {
+                return "No parameters";
+            }
+
+            var parameterParts = new List<string>();
+
+            foreach (MySqlParameter parameter in command.Parameters)
+            {
+                var parameterValue = parameter.Value == null || parameter.Value == DBNull.Value
+                    ? "NULL"
+                    : parameter.Value.ToString();
+
+                parameterParts.Add($"{parameter.ParameterName}={parameterValue}");
+            }
+
+            return string.Join(", ", parameterParts);
         }
 
         /// <summary>


### PR DESCRIPTION
https://app.asana.com/1/236678296282156/project/1205519043178369/task/1214069327295624?focus=true