### PR TITLE
BUG - Kendo-Icons version hardcoded to 4.9.0 due to the latest version (5.0.0) deprecating icons.

### DIFF
--- a/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
+++ b/FrontEnd/Modules/Admin/Views/Admin/Index.cshtml
@@ -8,7 +8,7 @@
     <title>Coder 3 - Admin</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/Communication/Views/Communication/Index.cshtml
+++ b/FrontEnd/Modules/Communication/Views/Communication/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/Communication/Views/Communication/Settings.cshtml
+++ b/FrontEnd/Modules/Communication/Views/Communication/Settings.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/Configuration/Views/Configuration/Index.cshtml
+++ b/FrontEnd/Modules/Configuration/Views/Configuration/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
+++ b/FrontEnd/Modules/Dashboard/Views/Dashboard/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion";

--- a/FrontEnd/Modules/DataSelector/Views/DataSelector/Index.cshtml
+++ b/FrontEnd/Modules/DataSelector/Views/DataSelector/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion";

--- a/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
+++ b/FrontEnd/Modules/DynamicItems/Views/DynamicItems/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/FileManager/Views/FileManager/Index.cshtml
+++ b/FrontEnd/Modules/FileManager/Views/FileManager/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/ImportExport/Views/ImportExport/Export.cshtml
+++ b/FrontEnd/Modules/ImportExport/Views/ImportExport/Export.cshtml
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/ImportExport/Views/ImportExport/Import.cshtml
+++ b/FrontEnd/Modules/ImportExport/Views/ImportExport/Import.cshtml
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/ImportExport/Views/ImportExport/Index.cshtml
+++ b/FrontEnd/Modules/ImportExport/Views/ImportExport/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/Search/Views/Search/Index.cshtml
+++ b/FrontEnd/Modules/Search/Views/Search/Index.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/History.cshtml
+++ b/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/History.cshtml
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/Index.cshtml
+++ b/FrontEnd/Modules/TaskAlerts/Views/TaskAlerts/Index.cshtml
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/Templates/Views/DynamicContent/Index.cshtml
+++ b/FrontEnd/Modules/Templates/Views/DynamicContent/Index.cshtml
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
 
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";

--- a/FrontEnd/Modules/Templates/Views/Templates/Index.cshtml
+++ b/FrontEnd/Modules/Templates/Views/Templates/Index.cshtml
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>

--- a/FrontEnd/Modules/VersionControl/Views/VersionControl/Index.cshtml
+++ b/FrontEnd/Modules/VersionControl/Views/VersionControl/Index.cshtml
@@ -13,7 +13,7 @@
     <title>Coder 3 - Versiebeheermodule</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://unpkg.com/@@progress/kendo-theme-material@11.1.0/dist/material-main.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons/dist/index.css" />
+<link rel="stylesheet" href="https://unpkg.com/@@progress/kendo-font-icons@4.9.0/dist/index.css" />
     <script>
         window.wiserVersion = "@Model.WiserVersion?.ToString()";
     </script>


### PR DESCRIPTION
Kendo Icons is van versie 4.9.0 naar 5.0.0 gegaan. Deze versie-upgrade is niet backwards compatible en zorgde ervoor dat veel icons niet meer beschikbaar waren.

De versie staat nu vast op 4.9.0, zodat niet automatisch de laatste versie wordt gebruikt en de iconen zichtbaar en bruikbaar blijven.